### PR TITLE
Add support  for groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.0 2024-11-26
+
+Courtesy of @oyvindkinsey:
+
+- Add support for fetching groups from Avi-on's API
+
+### Breaking changes
+- device.device_id is now device.avid to better reflect the underlying datamodel
+
 ## 0.6.0 2024-11-22
 
 Courtesy of @oyvindkinsey:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ DEV_REQUIRES = [
 
 setup(
     name="halohome",
-    version="0.6.0",
+    version="0.7.0",
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
@nayaverdier, I got inspired and ended up publishing https://github.com/oyvindkinsey/avionmqtt - this is a fully working mqtt bridge that has full two-way communication between the BLE mesh and Home Assistant via MQTT.

I basically haven't touched python prior to this project, so still need to do some work to handle SIGINT etc properly. 
It's functional rather than OOP based, but does depend on the Avi-on portion from halohome, and where it now also needs to have groups exposed.

Will you continue to support this project, or would you recommend I simply fork off the HTTP api portion as well, and make avionmqtt a standalone library?